### PR TITLE
Checkbox color adjustments

### DIFF
--- a/src/sass/components/checkbox.sass
+++ b/src/sass/components/checkbox.sass
@@ -26,7 +26,7 @@
                 cursor: pointer
 
                 &:hover
-                    background-color: map.get($theme-map, "primary")
+                    background-color: map.get($theme-map, "checkbox-hover")
 
                     img
                         filter: invert(100%) sepia(0%) saturate(0%) hue-rotate(219deg) brightness(102%) contrast(104%)
@@ -41,13 +41,20 @@
         .checkbox-disabled
             background-color: map.get($theme-map, "background1")
 
+
             .checkbox-mark
                 display: none
 
         .checkbox-active
             .checkbox-mark
                 background-color: map.get($theme-map, "primary")
+                cursor: pointer
 
+                &:hover
+                    background-color: map.get($theme-map, "checkbox-hover-active")
+
+                    img
+                        filter: invert(100%) sepia(0%) saturate(0%) hue-rotate(219deg) brightness(102%) contrast(104%)
                 img
                     filter: invert(100%) sepia(0%) saturate(0%) hue-rotate(219deg) brightness(102%) contrast(104%)
 

--- a/src/sass/components/checkbox.sass
+++ b/src/sass/components/checkbox.sass
@@ -41,7 +41,6 @@
         .checkbox-disabled
             background-color: map.get($theme-map, "background1")
 
-
             .checkbox-mark
                 display: none
 

--- a/src/sass/themes/dark.sass
+++ b/src/sass/themes/dark.sass
@@ -1,3 +1,3 @@
 @use "sass:map"
 
-$dark: ("background": #3b4252, "background1": #2e3440, "background2": #4c566a, "primary": #657ef8, "secondary": #eceff4, "text": white, "text-inverse": black, "select-boxes": #434c5e)
+$dark: ("background": #3b4252, "background1": #2e3440, "background2": #4c566a, "primary": #657ef8, "secondary": #eceff4, "text": white, "text-inverse": black, "select-boxes": #434c5e, "checkbox-hover": #5063bf, "checkbox-hover-active": #859aff)

--- a/src/sass/themes/light.sass
+++ b/src/sass/themes/light.sass
@@ -1,3 +1,3 @@
 @use "sass:map"
 
-$light: ("background": #f5f6fb, "background1": #f1f4f9, "background2": #eff2ff, "primary": #657ef8, "secondary": #e1e7ff, "text": black, "text-inverse": white, "select-boxes": white)
+$light: ("background": #f5f6fb, "background1": #f1f4f9, "background2": #eff2ff, "primary": #657ef8, "secondary": #e1e7ff, "text": black, "text-inverse": white, "select-boxes": white, "checkbox-hover": #5063bf, "checkbox-hover-active": #859aff)


### PR DESCRIPTION
Becomes more clear when you checked/unchecked a checkbox, since the hover color was the same color when the checkbox was ticked on, it wasn't particularly clear when an user clicked the checkbox or not.