### PR TITLE
add missing build dependency to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,20 @@ These requirements can't be easily installed so you should do it manually
 They're required only for some specific functions
 
 # Development
+## Dependency required for bundling to AppImage
+
+apt
+```sh
+sudo apt install libfuse2
+```
+pacman
+```sh
+sudo pacman -S fuse2
+```
+dnf
+```sh
+sudo dnf install libfuse2
+```
 
 ## Download source
 

--- a/README.md
+++ b/README.md
@@ -159,15 +159,15 @@ They're required only for some specific functions
 # Development
 ## Dependency required for bundling to AppImage
 
-apt
+### apt
 ```sh
 sudo apt install libfuse2
 ```
-pacman
+### pacman
 ```sh
 sudo pacman -S fuse2
 ```
-dnf
+### dnf
 ```sh
 sudo dnf install libfuse2
 ```


### PR DESCRIPTION
i suffered for 30 minutes when trying to understand why `yarn bundle` did not make an appimage