### PR TITLE
swap default virtual desktop resolution dimensions

### DIFF
--- a/src/defaultSettings.ts
+++ b/src/defaultSettings.ts
@@ -119,16 +119,16 @@ export default new Promise<void>(async (resolve) => {
                 /**
                  * Virtual Desktop Width
                  * 
-                 * @default 720
+                 * @default 1280
                  */
-                width: 720,
+                width: 1280,
 
                 /**
                  * Virtual Desktop Height
                  * 
-                 * @default 1280
+                 * @default 720
                  */
-                height: 1280
+                height: 720
             }
         },
     


### PR DESCRIPTION
When Virtual Desktop is enabled, it defaults to a resolution of 720px wide and 1280px high. This is a reverse of the standard 720p resolution – 1280x720.

This PR swaps the default width and height values to match the standard 720p resolution.