### PR TITLE
Add dxvk 2.1 to dxvks.yaml

### DIFF
--- a/public/dxvks.yaml
+++ b/public/dxvks.yaml
@@ -2,6 +2,10 @@
   uri: https://github.com/Sporif/dxvk-async/releases/download/2.0/dxvk-async-2.0.tar.gz
   recommended: false
 
+- version: '2.1'
+  uri: https://github.com/doitsujin/dxvk/releases/download/v2.1/dxvk-2.1.tar.gz
+  recommended: true
+  
 - version: '2.0'
   uri: https://github.com/doitsujin/dxvk/releases/download/v2.0/dxvk-2.0.tar.gz
   recommended: true


### PR DESCRIPTION
[DXVK 2.1 has been released](https://github.com/doitsujin/dxvk/releases/tag/v2.1) with improved support for graphics pipeline library. This PR updates the list of dxvk options to allow installation of 2.1.