### PR TITLE
Use per-server cache

### DIFF
--- a/src/ts/Patch.ts
+++ b/src/ts/Patch.ts
@@ -277,8 +277,9 @@ export default class Patch
     public static getPatchInfo(version: string, source: 'origin' | 'additional' = 'origin'): Promise<PatchInfo|null>
     {
         return new Promise(async (resolve, reject) => {
+            const patchCacheKey = `Patch.getPatchInfo.${version}.${source}.${await Game.server}`;
             const resolveOutput = async (output: PatchInfo|null, unityPlayerHash: string|null = null) => {
-                await Cache.set(`Patch.getPatchInfo.${version}.${source}`, {
+                await Cache.set(patchCacheKey, {
                     available: true,
                     output: output,
                     playerHash: unityPlayerHash
@@ -290,7 +291,7 @@ export default class Patch
             const rejectOutput = async (error: Error) => {
                 // Cache this error only on an hour
                 // because then the server can become alive
-                await Cache.set(`Patch.getPatchInfo.${version}.${source}`, {
+                await Cache.set(patchCacheKey, {
                     available: false,
                     error: error.message
                 }, 3600);
@@ -298,7 +299,7 @@ export default class Patch
                 reject(error);
             };
 
-            const cache = await Cache.get(`Patch.getPatchInfo.${version}.${source}`);
+            const cache = await Cache.get(patchCacheKey);
 
             // If we have result cached
             if (cache && !cache.expired)


### PR DESCRIPTION
This likely will fix #47. It fixes CN server using global game data cache triggered by the following:

 1. Open the launcher in global mode
 2. The launcher caches the global data
 3. Use the launcher to locate the launcher folder, update the config to point to the CN server
 4. Restart the launcher, now the launcher recognizes it's using CN server, but still downloads the global game due to the cache.

This patch adds server as the suffix of the cache key of the game data and patch, so that it won't use the cached data for the wrong server.

Also, avoid downloading the data if it's already cached.