### PR TITLE
feat(i18n): Added french translations

### DIFF
--- a/assets/locales/common.ftl
+++ b/assets/locales/common.ftl
@@ -17,3 +17,4 @@ game-name = {-game-name-1}{-game-name-2} {-game-name-3}{-game-name-4}
 en = English
 ru = Русский
 de = Deutsch
+fr = Français

--- a/assets/locales/fr/enhancements.ftl
+++ b/assets/locales/fr/enhancements.ftl
@@ -1,0 +1,58 @@
+wine = Wine
+
+synchronization = Synchronisation
+wine-sync-description = Technologie utilisé pour synchroniser les évènements wine internes
+
+language = Langue
+wine-lang-description = Langue utilisé dans l'environnement wine. Peut résoudre des problèmes de clavier
+system = Système
+
+borderless-window = Utiliser une fenêtre sans bordure
+virtual-desktop = Bureau virtuel
+
+game = Jeu
+
+hud = HUD
+
+fsr = FSR
+fsr-description = Permet d'upscale le jeu à la taille de l'écran. Pour l'utiliser, sélectionnez une résolution plus basse en jeu, et appuyez sur Alt+Entrée
+ultra-quality = Qualité ultra
+quality = Qualité
+balanced = Équilibré
+performance = Performances
+
+gamemode = Gamemode
+gamemode-description = Donne la priorité au jeu sur le reste des processus du système
+
+gamescope = Gamescope
+gamescope-description = Gamescope est un outil fait par Valve qui permet aux jeux de se lancer dans une instance Xwayland isolée, et qui est compatible avec les cartes graphiques AMD, Intel et NVidia
+
+discord-rpc = Activité Discord
+discord-rpc-description = Permet à Discord d'afficher à vos amis des informations sur le jeu auquel vous jouez actuellement
+title = Titre
+description = Description
+
+fps-unlocker = Déblocage des FPS
+
+enabled = Activer
+fps-unlocker-description = Enlève les limitations de FPS en modifiant la mémoire du jeu. Peut être détecté par l'anticheat
+
+power-saving = Économie d'énergie
+power-saving-description = Limite automatiquement les FPS à 10 et baisse la priorité du processus quand le jeu n'est plus focus (lors d'un alt+tab par exemple)
+
+monitor = Écran
+monitor-description = Écran sur lequel le jeu se lancera
+
+window-mode = Type de fenêtre
+borderless = Sans bordure
+popup = Popup
+fullscreen = Plein écran
+
+priority = Priorité
+priority-description = Priorité du processus du jeu
+realtime = Temps réel
+high = Haut
+above-normal = Au dessus de la normale
+normal = Normale
+below-normal = En dessous de la normal
+low = Bas

--- a/assets/locales/fr/environment.ftl
+++ b/assets/locales/fr/environment.ftl
@@ -1,0 +1,7 @@
+environment = Environnement
+game-command = Commande du jeu
+game-command-description = Commande utilisée pour lancer le jeu. %command% est remplacé par la commande générée automatiquement par le launcher. Vous pouvez utiliser par exemple : gamemoderun '%command%'
+new-variable = Nouvelle variable
+name = Nom
+value = Valeur
+add = Ajouter

--- a/assets/locales/fr/errors.ftl
+++ b/assets/locales/fr/errors.ftl
@@ -1,0 +1,36 @@
+launcher-folder-opening-error = Impossible d'ouvrir l'emplacement du launcher
+game-folder-opening-error = Impossible d'ouvrir l'emplacement du jeu
+config-file-opening-error = Impossible d'ouvrir le fichier de configuration
+debug-file-opening-error = Impossible d'ouvrir le fichier débug
+
+game-launching-failed = Impossible de lancer le jeu
+failed-get-selected-wine = Impossible de récupérer la version de wine sélectionnée
+downloading-failed = Le téléchargement a échoué
+unpacking-failed = L'extraction a échoué
+
+game-file-repairing-error = Impossible de réparer les fichiers du jeu
+integrity-files-getting-error = Impossible de récupérer les fichiers d'intégrité du jeu
+
+background-downloading-failed = Impossible de télécharger l'image de fond
+config-update-error = Impossible d'enregistrer la configuration
+wine-prefix-update-failed = Impossible de mettre à jour le préfix wine
+dxvk-install-failed = Impossible d'installer DXVK
+voice-package-deletion-error = La suppression des pack de voix a échoué
+
+game-diff-finding-error = Impossible de trouver la diff du jeu
+patch-info-fetching-error = Impossible de récupérer les informations du patch
+launcher-state-updating-error = Impossible de mettre à jour l'état du launcher
+
+package-not-available = Le packet {$package} n'est pas disponible
+wine-download-error = Le téléchargement de wine a échoué
+wine-unpack-errror = L'extraction de wine a échoué
+wine-install-failed = L'installation de wine a échoué
+dxvk-download-error = Le téléchargement de DXVK a échoué
+dxvk-unpack-error = L'extraction de DXVK a échoué
+dxvk-apply-error = L'application de DXVK a échoué
+
+downloaded-wine-list-failed = Impossible de lister les versions de wine téléchargées
+
+patch-sync-failed = Impossible de synchroniser le patch
+patch-state-check-failed = Impossible de déterminer l'état du patch
+game-patching-error = Le patch du jeu a échoué

--- a/assets/locales/fr/first_run.ftl
+++ b/assets/locales/fr/first_run.ftl
@@ -1,0 +1,54 @@
+welcome = Bienvenu
+
+welcome-page-message =
+    Bonjour ! Bienvenu dans An Anime Game Launcher
+
+    Nous devons préparer quelques choses et télécharger les composants par défaut avant que vous ne puissiez démarrer le jeu
+
+
+tos-violation-warning = Avertissement : Non-respect des CGU
+
+tos-violation-warning-message =
+    Ce launcher est un outil non-officiel, il n'est associé ni à {company-name}, ni à {company-alter-name}.
+
+    Cet outil est conçu pour faciliter l'accès au jeu {game-name} sur Linux, et a été créé dans le seul but d'installer et de lancer le jeu plus facilement.
+
+    L'outil utilise pour cela des composants existant pour fournir à l'utilisateur une expérience simple.
+
+    Cependant, certains composants utilisés ne respectent pas les Conditions Générales d'Utilisation de {company-name} pour {game-name}.
+
+    Ainsi, si vous utilisez ce launcher, votre compte joueur peut être identifié comme non conformes aux CGU par {company-name}/{company-alter-name}.
+
+    Si c'est le cas, étant donné que votre compte n'est pas conforme aux CGU, {company-name}/{company-alter-name} se réservent le droit d'agir comme bon leur semble. Leurs actions peuvent notamment inclure le bannissement de votre compte.
+
+    Si vous comprenez ces risques, appuyez sur "Continuer" pour venir explorer le monde de Teyvat !
+
+
+dependencies = Dépendances
+missing-dependencies-title = Il vous manque des dépendances !
+missing-dependencies-message = Vous devez installer certain packets sur votre système avant de continuer la procédure d'installation
+
+
+default-paths = Emplacements par défaut
+choose-default-paths = Choisissez les emplacements par défaut
+show-all-folders = Je sais ce que je fait
+show-all-folders-subtitle = Afficher plus de paramètres de sélection d'emplacement. « Do as I say »...
+runners-folder = Emplacement des runners
+dxvks-folder = Emplacement des versions de DXVK
+wine-prefix-folder = Emplacement du préfix wine
+game-installation-folder = Emplacement d'installation du jeu
+patch-folder = Emplacement du patch
+temp-folder = Dossier temporaire
+
+
+select-voice-packages = Sélectionnez les packs de voix
+
+
+download-components = Téléchargement des composants
+download-dxvk = Téléchargement de DXVK
+apply-dxvk = Application de DXVK
+
+
+finish = Terminer
+finish-title = Tout est bon !
+finish-message = Tous les composants ont été téléchargé. Vous pouvez désormais redémarrer le launcher et télécharger le jeu. Bienvenu au club !

--- a/assets/locales/fr/gamescope.ftl
+++ b/assets/locales/fr/gamescope.ftl
@@ -1,0 +1,13 @@
+game-resolution = Résolution du jeu
+gamescope-resolution = Résolution de Gamescope
+
+upscaling = Upscaling (mise à l'échelle intelligente)
+
+integer-scaling = Mise à l'échelle à l'entier
+integer-scaling-description = Transforme chaque pixel en un nombre entier de pixel de même couleur, sous la forme d'un carré ou d'un rectangle. Permet d'éviter l'effet de flou lors de la mise à l'échelle entre la Full-HD et la 4K par exemple
+gamescope-fsr-description = Une technique de mise à l'échelle Open Source développée par AMD pour avoir une meilleur qualité de mise à l'échelle
+nis-description = Une technologie de mise à l'échelle Open Source développée par NVidia comme alternative compatible avec les autres marques à leur solution DLSS qui est propriétaire. Ainsi, cette option foctionne non seulement sur les cartes graphiques NVidia, mais aussi sur celles d'Intel et d'AMD.
+
+other-settings = Autres paramètres
+framerate-limit = Limitation des FPS
+unfocused-framerate-limit = Limitation des FPS hors focus

--- a/assets/locales/fr/general.ftl
+++ b/assets/locales/fr/general.ftl
@@ -1,0 +1,47 @@
+appearance = Apparence
+modern = Moderne
+classic = Classique
+update-background = Mise à jour automatique de l'image de fond
+update-background-description = Télécharger l'image de fond du launcher officiel. Vous pouvez la désactiver pour utiliser une image personnalisée à la place
+
+launcher-language = Langue du launcher
+launcher-language-description = S'applique après un redémarrage
+
+game-voiceovers = Voiceover en jeu
+english = Anglais
+japanese = Japonais
+korean = Coréen
+chinese = Chinois
+
+repair-game = Réparer le jeu
+
+status = Statut
+
+game-version = Version du jeu
+game-not-installed = le jeu n'est pas installé
+
+game-predownload-available = Mise à jour du jeu disponible en pré-téléchargement : {$old} -> {$new}
+game-update-available = Mise à jour du jeu disponible : {$old} -> {$new}
+game-outdated = La version du jeu installée est trop ancienne et ne peut pas être mise à jour. Dernière version : {$latest}
+
+patch-version = Version du patch
+
+patch-not-available = patch non disponible
+patch-not-available-tooltip = Impossible d'accéder aux serveurs de patch
+
+patch-outdated = pas à jour ({$current})
+patch-outdated-tooltip = Le patch n'est pas à jour : {$current} -> {$latest}
+
+patch-preparation = préparation
+patch-preparation-tooltip = Le patch est en développement
+
+patch-testing-tooltip = Patch de test disponible
+
+selected-version = Version sélectionnée
+recommended-only = Versions recommandées uniquement
+
+wine-version = Version de wine
+wine-recommended-description = N'afficher que les versions recommandées de wine
+
+dxvk-version = Version de DXVK
+dxvk-recommended-description = N'afficher que les versions recommandées de DXVK

--- a/assets/locales/fr/main.ftl
+++ b/assets/locales/fr/main.ftl
@@ -1,0 +1,56 @@
+custom = Personalisé
+none = Auccun
+default = Par défaut
+details = Détails
+
+width = Largeur
+height = Hauteur
+
+# Menu items
+
+launcher-folder = Dossier du launcher
+game-folder = Dossier du jeu
+config-file = Fichier de configuration
+debug-file = Fichier débug
+about = À propos
+
+
+close = Fermer
+save = Sauvegarder
+continue = Continuer
+exit = Quitter
+check = Vérifier
+restart = Redémarer
+
+loading-data = Chargement des données
+downloading-background-picture = Téléchargement de l'image de fond
+loading-game-version = Chargement de la version du jeu
+loading-patch-status = Chargement du statut du patch
+loading-launcher-state = Chargement de l'état du launcher
+loading-launcher-state--game = Chargement de l'état du launcher : vérification de la version du jeu
+loading-launcher-state--voice = Chargement de l'état du launcher : vérification des voiceover en {$locale}
+loading-launcher-state--patch = Chargement de l'état du launcher : vérification des patch installés
+
+
+checking-free-space = Vérification de l'espace disque disponible
+downloading = Téléchargement
+unpacking = Décompression
+verifying-files = Vérification des fichiers
+repairing-files = Réparation des fichiers
+
+
+launch = Lancer
+apply-patch = Appliquer le patch
+download-wine = Télécharger wine
+create-prefix = Créer le préfix wine
+update = Mettre à jour
+download = Télécharger
+predownload-update = Pré-télécharger la mise à jour {$version} ({$size})
+
+main-window--patch-unavailable-tooltip = Les serveurs de patch ne sont pas disponible, et le launcher ne peut pas vérifier l'état de patch du jeu. Lancez le jeu à vos risques et périls
+main-window--patch-outdated-tooltip = Le patch n'est pas à jour ou encore en train d'être préparé. Il n'est donc pas encore disponible. Revenez plus tard pour voir son état
+main-window--version-outdated-tooltip = La version du jeu est trop ancienne et ne peut pas être mise à jour
+
+preferences = Préférences
+general = Général
+enhancements = Améliorations

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -13,7 +13,8 @@ fluent_templates::static_loader! {
 pub const SUPPORTED_LANGUAGES: &[LanguageIdentifier] = &[
     langid!("en-us"),
     langid!("ru-ru"),
-    langid!("de-de")
+    langid!("de-de"),
+    langid!("fr-fr")
 ];
 
 static mut LANG: LanguageIdentifier = langid!("en-us");


### PR DESCRIPTION
This commit adds the translation and registers the language in the code, so that french translations show up in the launcher.

This will probably need to be re-checked for consistency issues at some point, as I'm not sure I've used consistant terminology everywhere. Will probably do it next time there are major changes to do to the translations!

Some notes:

    - I didn't translate the app's name, though maybe it should be?
      Because of word ordering in French, having "Launcher" at the end
      sounds a bit off...

    - I took quite some liberty in some of the explanations, mostly in
      the "enhancements" part, to make it more understandable, because I
      felt like the English version wasn't clear enough (though maybe
      I'm just misunderstanding it...). I can change those to be closer
      to the English ones if needs be.

    - I used Unicode NBSPs (Non-Breaking Spaces) in some places, as it's
      what's grammatically correct in French. Though, those are easily
      confused for regular ASCII spaces, as they look visually identical
      in most editors. If there are any escape sequences I could use to
      make them stand out more, it'd probably be best!

    - Some of the lines are very long, I don't know if this is an issue,
      but I didn't want to add line breaks for fear it may break
      something in the file. If those can/need to be added, I can change
      that too!

    - I tried my best at translating the ToS warning, but I'm not a
      legal translator, so, of course, it has no legal value

This translations, though not perfect should be understandable to most French speakers :) If you have any comments or suggestion, feel free to leave them here!

![Screnshot of the launcher in French with the settings open and the translations file behind](https://user-images.githubusercontent.com/40790374/222960527-61ff732c-5e42-4436-a739-9fc3b7de5f39.png)
