### PR TITLE
Proton Prefix Decoration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 
 flamegraph.svg
 perf.data*
+
+*.patch
+*.diff
+*.log

--- a/src/ui/first_run/download_components.rs
+++ b/src/ui/first_run/download_components.rs
@@ -337,12 +337,12 @@ impl SimpleAsyncComponent for DownloadComponentsApp {
 
                 self.downloading_wine_version = self.selected_wine.clone().unwrap().title;
                 self.downloading_dxvk_version = self.selected_dxvk.clone().unwrap().name;
-                self.creating_prefix_path     = config.game.wine.prefix.to_string_lossy().to_string();
 
                 self.downloading = true;
                 self.downloading_wine = Some(false);
 
                 let wine = self.selected_wine.clone().unwrap();
+                self.creating_prefix_path     = wine.prefix_path(&config.components.path, config.game.wine.prefix.clone()).to_string_lossy().to_string();
                 let progress_bar_input = self.progress_bar.sender().clone();
 
                 std::thread::spawn(move || {
@@ -422,6 +422,7 @@ impl SimpleAsyncComponent for DownloadComponentsApp {
                 tracing::info!("Creating wine prefix");
 
                 let wine = self.selected_wine.as_ref().unwrap();
+                let true_prefix = wine.prefix_path(&config.components.path, config.game.wine.prefix.clone());
 
                 let wine = wine
                     .to_wine(Some(config.game.wine.builds.join(&wine.name)))
@@ -429,7 +430,7 @@ impl SimpleAsyncComponent for DownloadComponentsApp {
                     .with_arch(WineArch::Win64);
 
                 std::thread::spawn(move || {
-                    match wine.update_prefix(config.game.wine.prefix) {
+                    match wine.update_prefix(true_prefix) {
                         // Download DXVK
                         Ok(_) => sender.input(DownloadComponentsAppMsg::DownloadDXVK),
 
@@ -527,6 +528,7 @@ impl SimpleAsyncComponent for DownloadComponentsApp {
                 let dxvk = self.selected_dxvk.clone().unwrap();
 
                 let group = wine.find_group(&config.components.path).unwrap().unwrap();
+                let true_prefix = wine.prefix_path(&config.components.path, config.game.wine.prefix.clone());
 
                 // Apply DXVK if we need it
                 if wine.features.as_ref().unwrap_or(&group.features).need_dxvk {
@@ -534,7 +536,7 @@ impl SimpleAsyncComponent for DownloadComponentsApp {
                         .to_wine(Some(config.game.wine.builds.join(&wine.name)))
                         .with_loader(WineLoader::Current)
                         .with_arch(WineArch::Win64)
-                        .with_prefix(config.game.wine.prefix);
+                        .with_prefix(true_prefix);
 
                     std::thread::spawn(move || {
                         let params = InstallParams {

--- a/src/ui/main.rs
+++ b/src/ui/main.rs
@@ -1186,12 +1186,13 @@ impl SimpleComponent for App {
                                 sender.input(AppMsg::DisableButtons(true));
 
                                 std::thread::spawn(move || {
+                                    let true_prefix = wine.prefix_path(&config.components.path, config.game.wine.prefix.clone());
                                     let wine = wine
                                         .to_wine(Some(config.game.wine.builds.join(&wine.name)))
                                         .with_loader(WineLoader::Current)
                                         .with_arch(WineArch::Win64);
 
-                                    if let Err(err) = wine.update_prefix(&config.game.wine.prefix) {
+                                    if let Err(err) = wine.update_prefix(&true_prefix) {
                                         tracing::error!("Failed to create wine prefix");
 
                                         sender.input(AppMsg::Toast {

--- a/src/ui/preferences/general.rs
+++ b/src/ui/preferences/general.rs
@@ -828,9 +828,10 @@ impl SimpleAsyncComponent for GeneralApp {
 
                             let wine = version.to_wine(Some(config.game.wine.builds.join(&version.name)));
                             let wine_name = version.name.to_string();
+                            let true_prefix = version.prefix_path(&config.components.path, config.game.wine.prefix.clone());
 
                             std::thread::spawn(move || {
-                                match wine.update_prefix(&config.game.wine.prefix) {
+                                match wine.update_prefix(true_prefix) {
                                     Ok(_) => {
                                         config.game.wine.selected = Some(wine_name); 
 


### PR DESCRIPTION
This adds Prefix Decoration support. Used for Proton prefixes, where the WINE prefix lives in the `pfx` subdir in the Proton prefix, which is actually `STEAM_COMPAT_DATA_PATH`.

Requires https://github.com/an-anime-team/anime-launcher-sdk/pull/1 to be merged.