### PR TITLE
refactor(core): :bug: Use AtomicBool for READY

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,13 +27,13 @@ pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const APP_DEBUG: bool = cfg!(debug_assertions);
 
 /// Sets to `true` when the `App` component is ready (fully initialized)
-pub static mut READY: bool = false;
+pub static READY: AtomicBool = AtomicBool::new(false);
 
 // TODO: get rid of using this function in all the components' events
 //       e.g. by converting preferences pages into Relm4 Components
 /// Check if the app is ready
 pub fn is_ready() -> bool {
-    unsafe { READY }
+    READY.load(Ordering::Relaxed)
 }
 
 lazy_static::lazy_static! {

--- a/src/ui/first_run/main.rs
+++ b/src/ui/first_run/main.rs
@@ -174,9 +174,9 @@ impl SimpleComponent for FirstRunApp {
 
         unsafe {
             MAIN_WINDOW = Some(widgets.window.clone());
-
-            crate::READY = true;
         }
+
+        crate::READY.store(true, Ordering::Relaxed);
 
         tracing::info!("First run window initialized. App is ready");
 

--- a/src/ui/main/mod.rs
+++ b/src/ui/main/mod.rs
@@ -873,9 +873,7 @@ impl SimpleComponent for App {
             });
 
             // Mark app as loaded
-            unsafe {
-                crate::READY = true;
-            }
+            crate::READY.store(true, Ordering::Relaxed);
 
             tracing::info!("App is ready");
         });


### PR DESCRIPTION
It also removes `unsafe` for accessing `READY`.

> Be aware as there is no such thing as single-threaded code as long as interrupts are enabled. So even for microcontrollers, mutable statics are unsafe.

https://stackoverflow.com/a/72369696/12652912