### PR TITLE
feat(desktop): specify StartupWMClass

### DIFF
--- a/assets/anime-game-launcher.desktop
+++ b/assets/anime-game-launcher.desktop
@@ -5,3 +5,4 @@ Exec=AppRun
 Type=Application
 Categories=Game
 Terminal=false
+StartupWMClass=moe.launcher.an-anime-game-launcher


### PR DESCRIPTION
On some setups, a StartupWMClass is needed to correctly identify the app window as belonging to AAGL, in order to properly display the app icon and name.