### PR TITLE
Better labels for the payment processing options

### DIFF
--- a/src/ui/preferences/general/mod.rs
+++ b/src/ui/preferences/general/mod.rs
@@ -303,8 +303,8 @@ impl SimpleAsyncComponent for GeneralApp {
                     set_subtitle: &tr!("game-environment-description"),
 
                     set_model: Some(&gtk::StringList::new(&[
-                        "PC",
-                        "Android"
+                        "Hoyoverse",
+                        "Google Play"
                     ])),
 
                     set_selected: match CONFIG.launcher.environment {


### PR DESCRIPTION
The Environment labels have only ever been used to switch between payment processors.

This relabels them to simply be either Hoyoverse (transactions through the dev) or Google Play.