### PR TITLE
Add "Keywords=aagl" to desktop file

### DIFF
--- a/assets/anime-game-launcher.desktop
+++ b/assets/anime-game-launcher.desktop
@@ -5,3 +5,4 @@ Exec=AppRun
 Type=Application
 Categories=Game
 Terminal=false
+Keywords=aagl


### PR DESCRIPTION
This MR adds Keywords=aagl to .desktop file so the launcher is searchable with the term "aagl". The actual .desktop file which gets installed when installing from AUR is not in this repo but in [AUR itself](https://aur.archlinux.org/cgit/aur.git/tree/an-anime-game-launcher.desktop?h=an-anime-game-launcher-bin) so I couldn't create a MR for that file.
![resim](https://github.com/an-anime-team/an-anime-game-launcher/assets/108172910/3faa5ae8-27b7-43aa-99c5-761b441405a3)
