### PR TITLE
Release 3.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- (potentially) Fixed `game.log` file overfilling at the start of the game
+- (potentially) Fixed RAM filling with the buffered game logs
+
 ## [3.10.2] - 19.07.2024
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- (potentially) Fixed `game.log` file overfilling at the start of the game
-- (potentially) Fixed RAM filling with the buffered game logs
+- Fixed `game.log` file overfilling at the start of the game
+- Fixed RAM filling with the buffered game logs
+- Fixed Discord RPC updates
 
 ## [3.10.2] - 19.07.2024
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,8 +107,8 @@ dependencies = [
 
 [[package]]
 name = "anime-launcher-sdk"
-version = "1.16.9"
-source = "git+https://github.com/an-anime-team/anime-launcher-sdk?tag=1.16.9#048fad0e35e55455146fb2da7fb722bbcacdb778"
+version = "1.16.10"
+source = "git+https://github.com/an-anime-team/anime-launcher-sdk?tag=1.16.10#0603733f2bd7efb38255e1d24f4a33e7137c88f3"
 dependencies = [
  "anime-game-core",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,8 +107,8 @@ dependencies = [
 
 [[package]]
 name = "anime-launcher-sdk"
-version = "1.16.7"
-source = "git+https://github.com/an-anime-team/anime-launcher-sdk?tag=1.16.7#4589c81c27693643f3f73f8be6878f8f97c282d4"
+version = "1.16.8"
+source = "git+https://github.com/an-anime-team/anime-launcher-sdk?tag=1.16.8#759394a2f1413e9bfbd51c66a892489522f9f230"
 dependencies = [
  "anime-game-core",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,8 +107,8 @@ dependencies = [
 
 [[package]]
 name = "anime-launcher-sdk"
-version = "1.16.8"
-source = "git+https://github.com/an-anime-team/anime-launcher-sdk?tag=1.16.8#759394a2f1413e9bfbd51c66a892489522f9f230"
+version = "1.16.9"
+source = "git+https://github.com/an-anime-team/anime-launcher-sdk?tag=1.16.9#048fad0e35e55455146fb2da7fb722bbcacdb778"
 dependencies = [
  "anime-game-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ glib-build-tools = "0.20"
 
 [dependencies.anime-launcher-sdk]
 git = "https://github.com/an-anime-team/anime-launcher-sdk"
-tag = "1.16.9"
+tag = "1.16.10"
 features = ["all", "genshin"]
 
 # path = "../anime-launcher-sdk" # ! for dev purposes only

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ glib-build-tools = "0.20"
 
 [dependencies.anime-launcher-sdk]
 git = "https://github.com/an-anime-team/anime-launcher-sdk"
-tag = "1.16.7"
+tag = "1.16.8"
 features = ["all", "genshin"]
 
 # path = "../anime-launcher-sdk" # ! for dev purposes only

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ glib-build-tools = "0.20"
 
 [dependencies.anime-launcher-sdk]
 git = "https://github.com/an-anime-team/anime-launcher-sdk"
-tag = "1.16.8"
+tag = "1.16.9"
 features = ["all", "genshin"]
 
 # path = "../anime-launcher-sdk" # ! for dev purposes only

--- a/src/ui/about.rs
+++ b/src/ui/about.rs
@@ -95,30 +95,12 @@ impl SimpleComponent for AboutDialog {
 
             set_release_notes_version: &APP_VERSION,
             set_release_notes: &[
-                "<p>Added</p>",
-
-                "<ul>",
-                    "<li>Added \"Indonesia\" wine language option</li>",
-                    "<li>Added writing of the game's output to the \"game.log\" file in the launcher's folder</li>",
-                "</ul>",
-
                 "<p>Fixed</p>",
 
                 "<ul>",
-                    "<li>Fixed \"dwebp\" package name for fedora during initial setup</li>",
-                "</ul>",
-
-                "<p>Changed</p>",
-
-                "<ul>",
-                    "<li>Updated FPS unlocker version</li>",
-                    "<li>Changed background images processing logic</li>",
-                "</ul>",
-
-                "<p>Removed</p>",
-
-                "<ul>",
-                    "<li>Removed \"xdelta3\" dependency</li>",
+                    "<li>Fixed \"game.log\" file overfilling at the start of the game</li>",
+                    "<li>Fixed RAM filling with the buffered game logs</li>",
+                    "<li>Fixed Discord RPC updates</li>",
                 "</ul>"
             ].join("\n"),
 


### PR DESCRIPTION
# Short description

Hotfix release. For some minor part of the users wine was generating a lot of junk logs, filling up both RAM and `game.log`. This should be fixed in this update.

Since I'm not at home I can't test this update myself, so it will be tested only by the community members.

# Roadmap

- [x] Freeze major code changes
- [x] Update `CHANGELOG.md` and `about.rs`'s changelog
- [x] Wait for community testing of the beta builds
- [x] Release 3.10.3