### PR TITLE
Release 3.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.12.1] - 02.09.2024
+
+### Fixed
+
+- Fixed gamescope config file layout
+
 ## [3.12.0] - 01.09.2024
 
 ### Added
@@ -568,7 +574,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <br>
 
-[unreleased]: https://github.com/an-anime-team/an-anime-game-launcher/compare/3.12.0...next
+[unreleased]: https://github.com/an-anime-team/an-anime-game-launcher/compare/3.12.1...next
+[3.12.1]: https://github.com/an-anime-team/an-anime-game-launcher/compare/3.12.0...3.12.1
 [3.12.0]: https://github.com/an-anime-team/an-anime-game-launcher/compare/3.11.0...3.12.0
 [3.11.0]: https://github.com/an-anime-team/an-anime-game-launcher/compare/3.10.3...3.11.0
 [3.10.3]: https://github.com/an-anime-team/an-anime-game-launcher/compare/3.10.2...3.10.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,12 +197,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
-
-[[package]]
 name = "arrayref"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,9 +336,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -932,16 +926,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fluent"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a"
-dependencies = [
- "fluent-bundle",
- "unic-langid",
-]
-
-[[package]]
 name = "fluent-bundle"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -977,9 +961,9 @@ dependencies = [
 
 [[package]]
 name = "fluent-template-macros"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d2bcae1f3ec390c50161fcf130d3228750e9ecf965618584e046d884199b83"
+checksum = "b86ebacac709a063f57ee83d37c451d60dc873554f9bd828531fd1ec43209c80"
 dependencies = [
  "flume",
  "ignore",
@@ -992,23 +976,19 @@ dependencies = [
 
 [[package]]
 name = "fluent-templates"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197feb1e37209c6b3d29f0754b11fc070890efb2b1d761caac4e5287a200e9db"
+checksum = "f339cc149c01ba2f7b0feba2acde6dd6e4a48472daffe2ddfdd6073e564c60b3"
 dependencies = [
- "arc-swap",
- "fluent",
  "fluent-bundle",
  "fluent-langneg",
  "fluent-syntax",
  "fluent-template-macros",
  "flume",
- "heck",
  "ignore",
  "intl-memoizer",
  "log",
  "once_cell",
- "serde_json",
  "thiserror",
  "unic-langid",
 ]
@@ -2579,9 +2559,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.76"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,8 +63,8 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "anime-game-core"
-version = "1.24.1"
-source = "git+https://github.com/an-anime-team/anime-game-core?tag=1.24.1#0161c8def421e47679c4f5c721e92adf840b82a1"
+version = "1.24.2"
+source = "git+https://github.com/an-anime-team/anime-game-core?tag=1.24.2#dd0e9fd265d7600005840fe4cbda9f1a76d7b520"
 dependencies = [
  "anyhow",
  "bzip2",
@@ -113,8 +113,8 @@ dependencies = [
 
 [[package]]
 name = "anime-launcher-sdk"
-version = "1.20.1"
-source = "git+https://github.com/an-anime-team/anime-launcher-sdk?tag=1.20.1#8f1a9e165fc3d4da2e7719e6813eb1938d463ee2"
+version = "1.20.3"
+source = "git+https://github.com/an-anime-team/anime-launcher-sdk?tag=1.20.3#a101b856e8e2d7b57ca6566b2752d2c8ab7cc3d9"
 dependencies = [
  "anime-game-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ enum-ordinalize = "4.3"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 
-fluent-templates = "0.9"
+fluent-templates = "0.10"
 unic-langid = "0.9"
 
 human-panic = "2.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ glib-build-tools = "0.20"
 
 [dependencies.anime-launcher-sdk]
 git = "https://github.com/an-anime-team/anime-launcher-sdk"
-tag = "1.20.1"
+tag = "1.20.3"
 features = ["all", "genshin"]
 
 # path = "../anime-launcher-sdk" # ! for dev purposes only

--- a/src/ui/about.rs
+++ b/src/ui/about.rs
@@ -95,26 +95,10 @@ impl SimpleComponent for AboutDialog {
 
             set_release_notes_version: &APP_VERSION,
             set_release_notes: &[
-                "<p>Added</p>",
-
-                "<ul>",
-                    "<li>Added 4.8.0 and 5.0.0 voiceovers sizes</li>",
-                    "<li>Apply chmod 755 to extracted files if 7z was used</li>",
-                "</ul>",
-
-                "<p>Changed</p>",
-
-                "<ul>",
-                    "<li>Reworked gamescope settings</li>",
-                "</ul>",
-
                 "<p>Fixed</p>",
 
                 "<ul>",
-                    "<li>Create cache folder if it doesn't exist</li>",
-                    "<li>(potentially) fixed a bug with pre-download button</li>",
-                    "<li>Fixed calculation of unpacked files size due to API changes</li>",
-                    "<li>Respect downloaded file size in free space check</li>",
+                    "<li>Fixed gamescope config file layout</li>",
                 "</ul>"
             ].join("\n"),
 


### PR DESCRIPTION
# Short description

In the previous update I made a mistake in the gamescope config layout. This update supposed to fix it, so width-height-related settings will not be returned to default values each launcher restart.

# Roadmap

- [x] Freeze major code changes
- [x] Update `CHANGELOG.md` and `about.rs`'s changelog
- [x] Release 3.12.1