### PR TITLE
Sophon repairer and shi

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -178,6 +178,7 @@ fn main() -> anyhow::Result<()> {
         .with_filter(filter_fn(move |metadata| {
             !metadata.target().contains("rustls") &&
             !metadata.target().contains("reqwest") &&
+            !metadata.target().contains("h2") &&
             !metadata.target().contains("hyper_util") &&
             !no_verbose_tracing
         }));
@@ -192,6 +193,7 @@ fn main() -> anyhow::Result<()> {
         .with_filter(filter_fn(|metadata| {
             !metadata.target().contains("rustls") &&
             !metadata.target().contains("reqwest") &&
+            !metadata.target().contains("h2") &&
             !metadata.target().contains("hyper_util")
         }));
 

--- a/src/ui/components/progress_bar.rs
+++ b/src/ui/components/progress_bar.rs
@@ -44,6 +44,8 @@ pub enum ProgressBarMsg {
 
     /// (current bytes, total bytes) 
     UpdateProgress(u64, u64),
+    /// (current items, total items)
+    UpdateProgressCounter(u64, u64),
 
     UpdateFromState(DiffUpdate),
     SetVisible(bool)
@@ -126,6 +128,15 @@ impl SimpleAsyncComponent for ProgressBar {
                 self.downloaded = Some((
                     prettify_bytes(curr),
                     prettify_bytes(total)
+                ));
+            }
+
+            ProgressBarMsg::UpdateProgressCounter(curr, total) => {
+                self.fraction = curr as f64 / total as f64;
+
+                self.downloaded = Some((
+                    curr.to_string(),
+                    total.to_string()
                 ));
             }
 


### PR DESCRIPTION
Needs launcher sdk update to bump core to 1.32.0

Which would include the following core changes: https://github.com/an-anime-team/anime-game-core/compare/1.31.1...1.32.0

Especially the commit https://github.com/an-anime-team/anime-game-core/commit/b0ca8c77406b54ab8200ac73fd04c1772eb5c77c which fixed the predownload issues