### PR TITLE
Release 3.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed preload not using the configured temporary folder
+
 ## [3.15.0] - 11.07.2025
 
 ### Changed

--- a/src/ui/about.rs
+++ b/src/ui/about.rs
@@ -86,10 +86,10 @@ impl SimpleComponent for AboutDialog {
 
             set_release_notes_version: &APP_VERSION,
             set_release_notes: &[
-                "<p>Changed</p>",
+                "<p>Fixed</p>",
 
                 "<ul>",
-                    "<li>Improved sophon implementation to utilize multiple threads</li>",
+                    "<li>Fixed preload not using the configured temporary folder</li>",
                 "</ul>"
             ].join("\n")
         }

--- a/src/ui/main/mod.rs
+++ b/src/ui/main/mod.rs
@@ -1102,6 +1102,8 @@ impl SimpleComponent for App {
 
                     std::thread::spawn(move || {
                         for mut diff in diffs {
+                            diff = diff.with_temp_folder(tmp.clone());
+
                             let result = diff.download_to(&tmp, clone!(
                                 #[strong]
                                 progress_bar_input,


### PR DESCRIPTION
# Short description

Quickfix for preload
# Roadmap

    * [x]  Freeze major code changes

    * [x]  Update `CHANGELOG.md` and `about.rs`'s changelog

    * [x]  Release 3.15.1

