### PR TITLE
Update classic mode default size

### DIFF
--- a/src/ui/main/mod.rs
+++ b/src/ui/main/mod.rs
@@ -126,11 +126,11 @@ impl SimpleComponent for App {
             set_default_size: (
                 match model.style {
                     LauncherStyle::Modern => 900,
-                    LauncherStyle::Classic => 1094 // (w = 1280 / 730 * h, where 1280x730 is default background picture resolution)
+                    LauncherStyle::Classic => 1152 // (w = 2560 / 1440 * h, where 2560x1440 is default background picture resolution)
                 },
                 match model.style {
                     LauncherStyle::Modern => 600,
-                    LauncherStyle::Classic => 624
+                    LauncherStyle::Classic => 648
                 }
             ),
 


### PR DESCRIPTION
The default background image size is 2560x1440 now.

Also I changed the default height to 648 because: 
* 648 is divisible with 2,4,8
* 648 * (2560/1440) is exactly 1152 (no decimals).

Though maybe it could be changed to just 720p.