### PR TITLE
Fix tr! returning empty strings

### DIFF
--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -115,16 +115,16 @@ macro_rules! tr {
     ($id:expr, { $($key:literal = $value:expr),* }) => {
         {
             use std::collections::HashMap;
+            use fluent_templates::Loader;
             use fluent_templates::fluent_bundle::FluentValue;
 
             let mut args = HashMap::new();
 
             $(
-                args.insert($key, FluentValue::from($value));
+                args.insert($key.into(), FluentValue::from($value));
             )*
 
-            $crate::i18n::LOCALES.lookup_no_default_fallback($crate::i18n::get_lang(), $id, Some(&args))
-                .unwrap_or_default()
+            $crate::i18n::LOCALES.lookup_complete($crate::i18n::get_lang(), $id, Some(&args))
         }
     };
 }


### PR DESCRIPTION
before:
<img width="626" height="241" alt="изображение" src="https://github.com/user-attachments/assets/14eea794-1849-4430-baf4-01f5bf89561e" />
after:
<img width="627" height="211" alt="изображение" src="https://github.com/user-attachments/assets/4f7a7b4d-98ab-48e3-8db6-42e022fcc3f8" />

I have no idea what that crate's naming is and why it returned empty strings.