### PR TITLE
feat: introduce DXVK installation check

### DIFF
--- a/assets/locales/en/main.ftl
+++ b/assets/locales/en/main.ftl
@@ -61,6 +61,7 @@ apply-patch = Apply patch
 disable-telemetry = Disable telemetry
 download-wine = Download wine
 create-prefix = Create prefix
+install-dxvk = Install DXVK
 update = Update
 download = Download
 predownload-update = Pre-download {$version} update ({$size})

--- a/src/ui/main/install_dxvk.rs
+++ b/src/ui/main/install_dxvk.rs
@@ -1,51 +1,130 @@
-use relm4::prelude::*;
+use relm4::{
+    prelude::*,
+    Sender
+};
+
+use gtk::glib::clone;
 
 use anime_launcher_sdk::wincompatlib::prelude::*;
 
 use anime_launcher_sdk::config::ConfigExt;
 use anime_launcher_sdk::genshin::config::Config;
 
-use std::time::SystemTime;
+use anime_launcher_sdk::components::dxvk::Version;
 
 use crate::*;
+use crate::ui::components::*;
 
 use super::{App, AppMsg};
 
-pub fn install_dxvk(sender: ComponentSender<App>) {
+pub fn install_dxvk(sender: ComponentSender<App>, progress_bar_input: Sender<ProgressBarMsg>) {
     let config = Config::get().unwrap();
 
     match config.get_selected_wine() {
-        Ok(Some(wine)) => {
+        Ok(Some(wine_config)) => {
             sender.input(AppMsg::DisableButtons(true));
 
-            std::thread::spawn(move || {
-                let wine = wine
-                    .to_wine(config.components.path, Some(config.game.wine.builds.join(&wine.name)))
-                    .with_prefix(config.game.wine.prefix)
-                    .with_loader(WineLoader::Current);
+            std::thread::spawn(clone!(
+                #[strong] sender,
+                move || {
+                    let components_path = config.components.path.clone();
 
-                let dxvk_folder = use_latest_dxvk(config.game.dxvk.builds);
+                    let wine = wine_config
+                        .to_wine(
+                            components_path.clone(),
+                            Some(config.game.wine.builds.join(&wine_config.name)),
+                        )
+                        .with_prefix(config.game.wine.prefix)
+                        .with_loader(WineLoader::Current);
 
-                if let Err(err) = Dxvk::install(&wine, dxvk_folder, InstallParams::default()) {
-                    tracing::error!("Failed to install DXVK: {}", err);
+                    let latest = match Version::latest(components_path) {
+                        Ok(version) => version,
+                        Err(err) => {
+                            tracing::error!("Failed to get latest DXVK version: {}", err);
+                            sender.input(AppMsg::Toast {
+                                title: tr!("dxvk-install-failed"),
+                                description: Some(err.to_string()),
+                            });
+                            sender.input(AppMsg::DisableButtons(false));
+                            return;
+                        }
+                    };
 
-                    sender.input(AppMsg::Toast {
-                        title: tr!("dxvk-install-failed"),
-                        description: Some(err.to_string()),
+                    let dxvk_folder = config.game.dxvk.builds.join(&latest.name);
+
+                    if !dxvk_folder.exists() {
+                        match Installer::new(latest.uri) {
+                            Ok(mut installer) => {
+                                if let Some(temp_folder) = &config.launcher.temp {
+                                    installer.temp_folder = temp_folder.to_path_buf();
+                                }
+
+                                sender.input(AppMsg::SetDownloading(true));
+
+                                installer.install(&config.game.dxvk.builds, clone!(
+                                    #[strong] sender,
+                                    move |state| {
+                                        match state {
+                                            InstallerUpdate::DownloadingError(ref err) => {
+                                                tracing::error!("DXVK download failed: {err}");
+                                                sender.input(AppMsg::Toast {
+                                                    title: tr!("dxvk-download-error"),
+                                                    description: Some(err.to_string())
+                                                });
+                                            }
+                                            InstallerUpdate::UnpackingError(ref err) => {
+                                                tracing::error!("DXVK unpacking failed: {err}");
+                                                sender.input(AppMsg::Toast {
+                                                    title: tr!("dxvk-unpack-error"),
+                                                    description: Some(err.clone())
+                                                });
+                                            }
+                                            _ => {}
+                                        }
+
+                                        #[allow(unused_must_use)] {
+                                            progress_bar_input.send(ProgressBarMsg::UpdateFromState(
+                                                DiffUpdate::InstallerUpdate(state)
+                                            ));
+                                        }
+                                    }
+                                ));
+
+                                sender.input(AppMsg::SetDownloading(false));
+                                sender.input(AppMsg::UpdateLauncherState {
+                                    perform_on_download_needed: false,
+                                    show_status_page: true
+                                });
+                            }
+                            Err(err) => {
+                                tracing::error!("Failed to download DXVK: {}", err);
+                                sender.input(AppMsg::Toast {
+                                    title: tr!("dxvk-download-error"),
+                                    description: Some(err.to_string())
+                                });
+                            }
+                        }
+                    }
+
+                    if let Err(err) = Dxvk::install(&wine, dxvk_folder, InstallParams::default()) {
+                        tracing::error!("Failed to install DXVK: {}", err);
+                        sender.input(AppMsg::Toast {
+                            title: tr!("dxvk-install-failed"),
+                            description: Some(err.to_string()),
+                        });
+                    }
+
+                    sender.input(AppMsg::DisableButtons(false));
+                    sender.input(AppMsg::UpdateLauncherState {
+                        perform_on_download_needed: false,
+                        show_status_page: true,
                     });
                 }
-
-                sender.input(AppMsg::DisableButtons(false));
-                sender.input(AppMsg::UpdateLauncherState {
-                    perform_on_download_needed: false,
-                    show_status_page: true,
-                });
-            });
+            ));
         }
 
         Ok(None) => {
             tracing::error!("Failed to get selected wine executable");
-
             sender.input(AppMsg::Toast {
                 title: tr!("failed-get-selected-wine"),
                 description: None,
@@ -54,42 +133,10 @@ pub fn install_dxvk(sender: ComponentSender<App>) {
 
         Err(err) => {
             tracing::error!("Failed to get selected wine executable: {err}");
-
             sender.input(AppMsg::Toast {
                 title: tr!("failed-get-selected-wine"),
                 description: Some(err.to_string()),
             });
         }
-    }
-
-}
-
-pub fn use_latest_dxvk(builds_path: PathBuf) -> PathBuf {
-    let mut latest: Option<(SystemTime, PathBuf)> = None;
-
-    if let Ok(entries) = std::fs::read_dir(&builds_path) {
-        for entry in entries.filter_map(Result::ok) {
-            let path = entry.path();
-            let key_file = path.join("x64/dxgi.dll");
-            
-            if !key_file.exists() {
-                continue;
-            }
-
-            if let Ok(metadata) = std::fs::metadata(&key_file) {
-                if let Ok(modified) = metadata.modified() {
-                    match &latest {
-                        Some((latest_time, _)) if *latest_time >= modified => {}
-                        _ => latest = Some((modified, path.clone())),
-                    }
-                }
-            }
-        }
-    }
-
-    if let Some((_, path)) = latest {
-        path
-    } else {
-        builds_path
     }
 }

--- a/src/ui/main/install_dxvk.rs
+++ b/src/ui/main/install_dxvk.rs
@@ -1,0 +1,95 @@
+use relm4::prelude::*;
+
+use anime_launcher_sdk::wincompatlib::prelude::*;
+
+use anime_launcher_sdk::config::ConfigExt;
+use anime_launcher_sdk::genshin::config::Config;
+
+use std::time::SystemTime;
+
+use crate::*;
+
+use super::{App, AppMsg};
+
+pub fn install_dxvk(sender: ComponentSender<App>) {
+    let config = Config::get().unwrap();
+
+    match config.get_selected_wine() {
+        Ok(Some(wine)) => {
+            sender.input(AppMsg::DisableButtons(true));
+
+            std::thread::spawn(move || {
+                let wine = wine
+                    .to_wine(config.components.path, Some(config.game.wine.builds.join(&wine.name)))
+                    .with_prefix(config.game.wine.prefix)
+                    .with_loader(WineLoader::Current);
+
+                let dxvk_folder = use_latest_dxvk(config.game.dxvk.builds);
+
+                if let Err(err) = Dxvk::install(&wine, dxvk_folder, InstallParams::default()) {
+                    tracing::error!("Failed to install DXVK: {}", err);
+
+                    sender.input(AppMsg::Toast {
+                        title: tr!("dxvk-install-failed"),
+                        description: Some(err.to_string()),
+                    });
+                }
+
+                sender.input(AppMsg::DisableButtons(false));
+                sender.input(AppMsg::UpdateLauncherState {
+                    perform_on_download_needed: false,
+                    show_status_page: true,
+                });
+            });
+        }
+
+        Ok(None) => {
+            tracing::error!("Failed to get selected wine executable");
+
+            sender.input(AppMsg::Toast {
+                title: tr!("failed-get-selected-wine"),
+                description: None,
+            });
+        }
+
+        Err(err) => {
+            tracing::error!("Failed to get selected wine executable: {err}");
+
+            sender.input(AppMsg::Toast {
+                title: tr!("failed-get-selected-wine"),
+                description: Some(err.to_string()),
+            });
+        }
+    }
+
+}
+
+pub fn use_latest_dxvk(builds_path: PathBuf) -> PathBuf {
+    let mut latest: Option<(SystemTime, PathBuf)> = None;
+
+    if let Ok(entries) = std::fs::read_dir(&builds_path) {
+        for entry in entries.filter_map(Result::ok) {
+            let path = entry.path();
+            let key_file = path.join("x64/dxgi.dll");
+            
+            if !key_file.exists() {
+                continue;
+            }
+
+            if let Ok(metadata) = std::fs::metadata(&key_file) {
+                if let Ok(modified) = metadata.modified() {
+                    match &latest {
+                        Some((latest_time, _)) if *latest_time >= modified => {}
+                        _ => latest = Some((modified, path.clone())),
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some((_, path)) = latest {
+        path
+    } else {
+        builds_path
+    }
+}

--- a/src/ui/main/mod.rs
+++ b/src/ui/main/mod.rs
@@ -1229,7 +1229,9 @@ impl SimpleComponent for App {
                         download_wine::download_wine(sender, self.progress_bar.sender().to_owned())
                     }
                     LauncherState::PrefixNotExists => create_prefix::create_prefix(sender),
-                    LauncherState::DxvkNotInstalled => install_dxvk::install_dxvk(sender),
+                    LauncherState::DxvkNotInstalled => {
+                        install_dxvk::install_dxvk(sender, self.progress_bar.sender().to_owned())
+                    }
 
                     LauncherState::GameUpdateAvailable(diff)
                     | LauncherState::GameNotInstalled(diff)

--- a/src/ui/main/mod.rs
+++ b/src/ui/main/mod.rs
@@ -5,6 +5,7 @@ use gtk::glib::clone;
 
 mod repair_game;
 mod download_wine;
+mod install_dxvk;
 mod create_prefix;
 mod download_diff;
 mod migrate_folder;
@@ -413,7 +414,8 @@ impl SimpleComponent for App {
 
                                                 Some(LauncherState::FolderMigrationRequired { .. }) |
                                                 Some(LauncherState::WineNotInstalled) |
-                                                Some(LauncherState::PrefixNotExists) => "document-save-symbolic",
+                                                Some(LauncherState::PrefixNotExists) | 
+                                                Some(LauncherState::DxvkNotInstalled) => "document-save-symbolic",
 
                                                 Some(LauncherState::GameUpdateAvailable(_)) |
                                                 Some(LauncherState::GameNotInstalled(_)) |
@@ -437,6 +439,7 @@ impl SimpleComponent for App {
 
                                                 Some(LauncherState::WineNotInstalled) => tr!("download-wine"),
                                                 Some(LauncherState::PrefixNotExists)  => tr!("create-prefix"),
+                                                Some(LauncherState::DxvkNotInstalled) => tr!("install-dxvk"),
 
                                                 Some(LauncherState::GameUpdateAvailable(diff)) |
                                                 Some(LauncherState::GameOutdated(diff)) |
@@ -1226,6 +1229,7 @@ impl SimpleComponent for App {
                         download_wine::download_wine(sender, self.progress_bar.sender().to_owned())
                     }
                     LauncherState::PrefixNotExists => create_prefix::create_prefix(sender),
+                    LauncherState::DxvkNotInstalled => install_dxvk::install_dxvk(sender),
 
                     LauncherState::GameUpdateAvailable(diff)
                     | LauncherState::GameNotInstalled(diff)


### PR DESCRIPTION
Solution to the very common issue of broken DXVK installations in the various launchers: checking if DXVK is actually installed before allowing launching the game.

Depends on: https://github.com/an-anime-team/anime-launcher-sdk/pull/27

<img width="1135" height="630" alt="image" src="https://github.com/user-attachments/assets/aefae110-ed3d-45a9-9da8-b6754d06dc7c" />
