### PR TITLE
Fix image size in Appearance options

### DIFF
--- a/src/ui/preferences/general/mod.rs
+++ b/src/ui/preferences/general/mod.rs
@@ -174,8 +174,9 @@ impl SimpleAsyncComponent for GeneralApp {
                             #[watch]
                             set_active: model.style == LauncherStyle::Modern,
 
-                            gtk::Image {
-                                set_resource: Some(&format!("{APP_RESOURCE_PATH}/images/modern.svg"))
+                            gtk::Picture {
+                                set_resource: Some(&format!("{APP_RESOURCE_PATH}/images/modern.svg")),
+                                set_content_fit: gtk::ContentFit::ScaleDown
                             },
 
                             connect_clicked => GeneralAppMsg::UpdateLauncherStyle(LauncherStyle::Modern)
@@ -200,8 +201,9 @@ impl SimpleAsyncComponent for GeneralApp {
                             #[watch]
                             set_active: model.style == LauncherStyle::Classic,
 
-                            gtk::Image {
-                                set_resource: Some(&format!("{APP_RESOURCE_PATH}/images/classic.svg"))
+                            gtk::Picture {
+                                set_resource: Some(&format!("{APP_RESOURCE_PATH}/images/classic.svg")),
+                                set_content_fit: gtk::ContentFit::ScaleDown
                             },
 
                             connect_clicked => GeneralAppMsg::UpdateLauncherStyle(LauncherStyle::Classic)


### PR DESCRIPTION
Fixes the image size on gtk >=4.19.2

Relevant issue: #582 

Context:
- https://discourse.gnome.org/t/gtk-image-set-pixel-size-stopped-scaling-image-in-gtk-4-19-2/29482
- https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/8627

The image is now true to the svg size (it used to look weirdly blurry before). If that doesn't look as wanted, the svg files can be adjusted to be bigger to match the old look (but probably less blurry)

This is how it looks now:

<img width="822" height="682" alt="изображение" src="https://github.com/user-attachments/assets/ae878b82-2ed3-4880-8952-b767ef450dc0" />


