### PR TITLE
fix: Don't show import game button when voiceovers need to be downloaded.

### DIFF
--- a/src/ui/main/mod.rs
+++ b/src/ui/main/mod.rs
@@ -654,8 +654,7 @@ impl SimpleComponent for App {
 
                                         #[watch]
                                         set_visible: matches!(model.state.as_ref(),
-                                            Some(LauncherState::GameNotInstalled(_)) |
-                                            Some(LauncherState::VoiceNotInstalled(_))
+                                            Some(LauncherState::GameNotInstalled(_))
                                         ) && !model.kill_game_button,
 
                                         #[name = "import_game_button"]


### PR DESCRIPTION
Noticed when trying to import an older version of the game of which only voiceovers needed to be updated, we probably should avoid showing the button in such case.