### PR TITLE
Repair improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,8 +57,8 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anime-game-core"
-version = "1.38.7"
-source = "git+https://github.com/an-anime-team/anime-game-core?tag=1.38.7#6e9e4b97d4a2b1f7bcee0047861014d002fb65ee"
+version = "1.38.8"
+source = "git+https://github.com/an-anime-team/anime-game-core?tag=1.38.8#de96f35b5a7e863f077d27abd50f6ee977cc92de"
 dependencies = [
  "anyhow",
  "bzip2 0.4.4",
@@ -108,8 +108,8 @@ dependencies = [
 
 [[package]]
 name = "anime-launcher-sdk"
-version = "1.35.9"
-source = "git+https://github.com/an-anime-team/anime-launcher-sdk?tag=1.35.9#8d4eea31fa4a54800fe3d63702803713543bcd02"
+version = "1.35.10"
+source = "git+https://github.com/an-anime-team/anime-launcher-sdk?tag=1.35.10#c0991afb76878f17abf754effa64d86125af8110"
 dependencies = [
  "anime-game-core",
  "anyhow",
@@ -3085,8 +3085,8 @@ dependencies = [
 
 [[package]]
 name = "sophon-lib"
-version = "0.1.5"
-source = "git+https://github.com/dawn-winery/sophon-tools.git?tag=v0.1.5#898581c4962682ab911a58ab90226095304db08a"
+version = "0.1.6"
+source = "git+https://github.com/dawn-winery/sophon-tools.git?tag=v0.1.6#89f4a70476f7e5c24f03a6c269a8b291372cfd5e"
 dependencies = [
  "bytes",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ glib-build-tools = "0.20"
 
 [dependencies.anime-launcher-sdk]
 git = "https://github.com/an-anime-team/anime-launcher-sdk"
-tag = "1.35.9"
+tag = "1.35.10"
 features = ["all", "genshin"]
 
 # path = "../anime-launcher-sdk" # ! for dev purposes only

--- a/src/ui/main/repair_game.rs
+++ b/src/ui/main/repair_game.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::AtomicU64;
+
 use relm4::prelude::*;
 use relm4::Sender;
 use anime_launcher_sdk::anime_game_core::reqwest::blocking::Client;
@@ -71,9 +73,25 @@ pub fn repair_game(sender: ComponentSender<App>, progress_bar_input: Sender<Prog
         let repairer_temp = config.launcher.temp.unwrap_or_else(std::env::temp_dir);
 
         for manifest in manifests {
-            let mut repairer = SophonInstaller::new(client.clone(), &manifest, &repairer_temp)
-                .expect("failed to initialize sophon repairer");
+            let mut repairer = match SophonInstaller::new(client.clone(), &manifest, &repairer_temp)
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    tracing::error!("Error initializing repairer: {e:?}");
+                    sender.input(AppMsg::Toast {
+                        title: "Repair error".to_owned(),
+                        description: Some(e.to_string())
+                    });
+                    continue;
+                }
+            };
             repairer.mode_repair = true;
+            repairer.inplace = true;
+            repairer.chunks_in_mem = true;
+            repairer.chunks_queue_data_limit = Some(2 * 1024 * 1024 * 1024); // 2GiB
+
+            let total_files_to_repair = AtomicU64::new(0);
+            let total_to_repair = &total_files_to_repair;
 
             let updater = |msg: SophonRepairerUpdate| match msg {
                 SophonRepairerUpdate::CheckingFilesProgress {
@@ -86,14 +104,17 @@ pub fn repair_game(sender: ComponentSender<App>, progress_bar_input: Sender<Prog
                 }
 
                 SophonRepairerUpdate::DownloadingProgressFiles {
-                    total_files,
-                    downloaded_files
+                    downloaded_files, ..
                 } => {
-                    tracing::trace!(downloaded_files, total_files, "Repairing progress");
+                    tracing::trace!(
+                        downloaded_files,
+                        total_to_repair = total_to_repair.load(Ordering::Acquire),
+                        "Repairing progress"
+                    );
 
                     progress_bar_input.send(ProgressBarMsg::UpdateProgressCounter(
                         downloaded_files,
-                        total_files
+                        total_to_repair.load(Ordering::Acquire)
                     ));
                 }
 
@@ -104,9 +125,11 @@ pub fn repair_game(sender: ComponentSender<App>, progress_bar_input: Sender<Prog
                 }
 
                 SophonRepairerUpdate::DownloadingStarted {
-                    ..
+                    total_files, ..
                 } => {
                     tracing::trace!("Repairing started");
+
+                    total_to_repair.store(total_files, Ordering::Release);
 
                     progress_bar_input
                         .send(ProgressBarMsg::UpdateCaption(Some(tr!("repairing-files"))));


### PR DESCRIPTION
See also: [sophon-tools changes](https://dawn.wine/dawn-winery/sophon-tools/compare/v0.1.5...v0.1.6)

And also https://github.com/an-anime-team/the-honkers-railway-launcher/pull/366

- Fixed repair progress reporting
- Improved it as well by having the "total" number show amount of failed files at the end of the check
- Fixed some discovered inefficiencies in download like a chunk being processed twice if a file has it twice (so N occurences of the same chunk in a file would result in an N^2 amount of writes of that chunk into a file instead of just N)